### PR TITLE
6 add email mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ USERTYPE="admin"
 - `SECRET_KEY` - The key to initialise SQLalchemy
 - `DATABASE_PASSWORD` - The password that will be used to encrypt `app.db`
 
+If running the app in development without the required setup for emails, set USE_MOCK_EMAIL to 'true' (a string).
+When an email is 'sent' in this mode, the link (create account or reset password) is instead printed to the terminal, and can be used as usual:
+
+``` shell
+USE_MOCK_EMAIL='true'
+```
+
+If proper email function should be used (i.e. where AWS is set up), unset this environment variable, or set it to anything other than 'true' (e.g. 'false'):
+
+``` shell
+unset USE_MOCK_EMAIL
+USE_MOCK_EMAIL='false'
+```
+
 ### Database Setup
 1. Initialise the Database Schema:
 

--- a/README.md
+++ b/README.md
@@ -73,14 +73,14 @@ If running the app in development without the required setup for emails, set USE
 When an email is 'sent' in this mode, the link (create account or reset password) is instead printed to the terminal, and can be used as usual:
 
 ``` shell
-USE_MOCK_EMAIL='true'
+export USE_MOCK_EMAIL='true'
 ```
 
 If proper email function should be used (i.e. where AWS is set up), unset this environment variable, or set it to anything other than 'true' (e.g. 'false'):
 
 ``` shell
 unset USE_MOCK_EMAIL
-USE_MOCK_EMAIL='false'
+export USE_MOCK_EMAIL='false'
 ```
 
 ### Database Setup

--- a/app/emails.py
+++ b/app/emails.py
@@ -53,6 +53,9 @@ def send_email_ses(sender, recipient, type):
     else: 
         return False
     
+    if (os.environ.get('USE_MOCK_EMAIL') == 'true') :
+        return True
+    
     ses_client = boto3.client(
         'ses',
         region_name="ap-southeast-1",  
@@ -99,6 +102,9 @@ def send_email_ses(sender, recipient, type):
 
 def get_welcome_email_details(recipient_encoded, token):
     link = f"https://uwaengineeringprojects.com/create_account?email={recipient_encoded}&token={token}"
+
+    if (os.environ.get('USE_MOCK_EMAIL') == 'true') :
+        print(f"Link: http://127.0.0.1:5000/create_account?email={recipient_encoded}&token={token}")
 
     subject = "Welcome to UWAttend"  
     
@@ -180,6 +186,9 @@ def get_welcome_email_details(recipient_encoded, token):
 
 def get_forgot_password_email_details(recipient_encoded, token):
     link = f"https://uwaengineeringprojects.com/reset_password?email={recipient_encoded}&token={token}"
+
+    if (os.environ.get('USE_MOCK_EMAIL') == 'true') :
+        print(f"Link: http://127.0.0.1:5000/reset_password?email={recipient_encoded}&token={token}")
 
     subject = "Password Reset Request"
 


### PR DESCRIPTION
Added 3 lines to emails.py to simulate email without actually sending
Links sent to emails are now printed to terminal so can be accessed by clicking on them
User is still added to db as usual, and token
Added details to set env var to readme 