### PR TITLE
5 modal popup to confirm editing session details

### DIFF
--- a/app/static/js/joinExistingSession.js
+++ b/app/static/js/joinExistingSession.js
@@ -2,14 +2,26 @@
 $("#submit").click(function (e) {
 	e.preventDefault();  // Prevent the default form submission
 
-    confirmSessionEdits();
-
+    const form = document.getElementById("sessionForm");
+    let updateStatus = form.getAttribute("data-update");
+    console.log(updateStatus);
+    if (updateStatus === 'true') {
+        confirmSessionEdits();
+    }
+    else {
+        checkSessionExists();
+    }
 });
 
 function confirmSessionEdits() {
     let modalTextElement = $("#confirmSessionEditsModalText").get(0);
     modalTextElement.innerHTML = "warning message here... ";
     $('#confirmSessionEditsModal').modal('show');
+}
+
+function confirmChanges() {
+    $('#confirmSessionEditsModal').modal('hide');
+    checkSessionExists();
 }
 
 function checkSessionExists() {

--- a/app/static/js/joinExistingSession.js
+++ b/app/static/js/joinExistingSession.js
@@ -14,9 +14,40 @@ $("#submit").click(function (e) {
 });
 
 function confirmSessionEdits() {
-    let modalTextElement = $("#confirmSessionEditsModalText").get(0);
-    //modalTextElement.innerHTML = "warning message here... ";
-    $('#confirmSessionEditsModal').modal('show');
+    let modalTextElement = $("#confirmSessionEditsModalChangesText").get(0);
+
+    //retrieve current session details
+    const currentSessionName = $("#currentSessionName").get(0).innerHTML;
+    const currentSessionTime = $("#currentSessionTime").get(0).innerHTML;
+    const currentSessionDate = $("#currentSessionDate").get(0).innerHTML;
+
+    //retrieve new session details
+    const newSessionName = $("#session_name").get(0).value;
+    const newSessionTime = $("#session_time").get(0).value;
+    const newSessionDate = $("#session_date").get(0).value;
+
+    modalTextElement.innerHTML = "";
+    let changesMade = false;
+
+    if (currentSessionName != newSessionName) {
+        modalTextElement.innerHTML += "<br>" + currentSessionName + " > " + newSessionName;
+        changesMade = true;
+    }
+    if (currentSessionTime != newSessionTime) {
+        modalTextElement.innerHTML += "<br>" + currentSessionTime + " > " + newSessionTime;
+        changesMade = true;
+
+    }
+    if (currentSessionDate != newSessionDate) {
+        modalTextElement.innerHTML += "<br>" + currentSessionDate + " > " + newSessionDate;
+        changesMade = true;
+    }
+
+    if (changesMade) {
+        $('#confirmSessionEditsModal').modal('show');
+    }
+
+
 }
 
 function confirmChanges() {

--- a/app/static/js/joinExistingSession.js
+++ b/app/static/js/joinExistingSession.js
@@ -15,7 +15,7 @@ $("#submit").click(function (e) {
 
 function confirmSessionEdits() {
     let modalTextElement = $("#confirmSessionEditsModalText").get(0);
-    modalTextElement.innerHTML = "warning message here... ";
+    //modalTextElement.innerHTML = "warning message here... ";
     $('#confirmSessionEditsModal').modal('show');
 }
 

--- a/app/static/js/joinExistingSession.js
+++ b/app/static/js/joinExistingSession.js
@@ -2,9 +2,15 @@
 $("#submit").click(function (e) {
 	e.preventDefault();  // Prevent the default form submission
 
-    checkSessionExists();
+    confirmSessionEdits();
 
 });
+
+function confirmSessionEdits() {
+    let modalTextElement = $("#confirmSessionEditsModalText").get(0);
+    modalTextElement.innerHTML = "warning message here... ";
+    $('#confirmSessionEditsModal').modal('show');
+}
 
 function checkSessionExists() {
 

--- a/app/templates/confirmSessionEdits.html
+++ b/app/templates/confirmSessionEdits.html
@@ -11,8 +11,6 @@
 				<p id="confirmSessionEditsModalChangesText"></p>
 				<br>
 				By confirming, you will edit the session details for students you have signed in only.
-				<br>
-				If you instead want to configure a new session, first exit that session (from the home page), then configure a new one.
 			</div>
 			<div class="modal-footer border-0 pt-0 d-flex justify-content-center">
 				<button type="button" class="btn btn-danger w-30 py-2" onclick="confirmChanges()">Confirm Changes</button>

--- a/app/templates/confirmSessionEdits.html
+++ b/app/templates/confirmSessionEdits.html
@@ -1,0 +1,17 @@
+<div class="modal fade" id="confirmSessionEditsModal" tabindex="-1" aria-labelledby="confirmSessionEditsModalLabel"
+	aria-hidden="true">
+	<div class="modal-dialog modal-dialog-centered">
+		<div class="modal-content">
+			<div class="modal-header border-0 pb-0 d-flex justify-content-center ">
+				<h1 class="modal-title fs-4" id="confirmSessionEditsModalLabel">Do you want to make changes?</h1>
+				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+			</div>
+			<div id="confirmSessionEditsModalText" class="modal-body text-center">
+				You are editing an existing session - not configuring a new one.
+			</div>
+			<div class="modal-footer border-0 pt-0 d-flex justify-content-center">
+				<button type="button" class="btn btn-danger w-30 py-2" onclick="checkSessionExists()">Make Changes</button>
+			</div>
+		</div>
+	</div>
+</div>

--- a/app/templates/confirmSessionEdits.html
+++ b/app/templates/confirmSessionEdits.html
@@ -10,7 +10,7 @@
 				You are editing an existing session - not configuring a new one.
 			</div>
 			<div class="modal-footer border-0 pt-0 d-flex justify-content-center">
-				<button type="button" class="btn btn-danger w-30 py-2" onclick="checkSessionExists()">Make Changes</button>
+				<button type="button" class="btn btn-danger w-30 py-2" onclick="confirmChanges()">Make Changes</button>
 			</div>
 		</div>
 	</div>

--- a/app/templates/confirmSessionEdits.html
+++ b/app/templates/confirmSessionEdits.html
@@ -3,11 +3,16 @@
 	<div class="modal-dialog modal-dialog-centered">
 		<div class="modal-content">
 			<div class="modal-header border-0 pb-0 d-flex justify-content-center ">
-				<h1 class="modal-title fs-4" id="confirmSessionEditsModalLabel">Do you want to make changes?</h1>
+				<h1 class="modal-title fs-4" id="confirmSessionEditsModalLabel">Edit the current session details</h1>
 				<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 			</div>
 			<div id="confirmSessionEditsModalText" class="modal-body text-center">
-				You are editing an existing session - not configuring a new one.
+				You are editing the details of the current session, with the following changes:
+				<span id="actualEditChanges"></span>
+				<br>
+				By confirming, you will edit the session details for students you have signed in only.
+				<br>
+				If you instead want to configure a new session, first exit that session (from the home page), then configure a new one.
 			</div>
 			<div class="modal-footer border-0 pt-0 d-flex justify-content-center">
 				<button type="button" class="btn btn-danger w-30 py-2" onclick="confirmChanges()">Make Changes</button>

--- a/app/templates/confirmSessionEdits.html
+++ b/app/templates/confirmSessionEdits.html
@@ -8,14 +8,14 @@
 			</div>
 			<div id="confirmSessionEditsModalText" class="modal-body text-center">
 				You are editing the details of the current session, with the following changes:
-				<span id="actualEditChanges"></span>
+				<p id="confirmSessionEditsModalChangesText"></p>
 				<br>
 				By confirming, you will edit the session details for students you have signed in only.
 				<br>
 				If you instead want to configure a new session, first exit that session (from the home page), then configure a new one.
 			</div>
 			<div class="modal-footer border-0 pt-0 d-flex justify-content-center">
-				<button type="button" class="btn btn-danger w-30 py-2" onclick="confirmChanges()">Make Changes</button>
+				<button type="button" class="btn btn-danger w-30 py-2" onclick="confirmChanges()">Confirm Changes</button>
 			</div>
 		</div>
 	</div>

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -5,9 +5,11 @@
 <div class="mt-4 mx-md-5 mx-2 d-flex flex-column align-items-center">
     <h2>Session Configuration</h2>
     {% if update %}
-    <p class="text-center">You are already in an active session.</p>
+    <p class="text-center">You are already in an active session.<br>
+        To configure a new session, first exit this session from the home page.
+    </p>
     <h4 class="text-center">{{ unit }}<span id="currentSessionName">{{ currentSession.sessionName }}</span><span id="currentSessionTime">{{ currentSession.sessionTime }}</span><span id="currentSessionDate">{{ currentSession.sessionDate }}</span></h4>
-    <p>Edit the session configuration below.</p>
+    <p class="text-center">Edit the current session details below.</p>		
     {% else %}
     <p class="text-center">
         You have no active session. <br> Configure a new session below to view your class list.

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -59,6 +59,7 @@
 </form>
 </div>
 
+{% include 'confirmSessionEdits.html'%}
 {% include 'joinExistingSession.html'%}
 <script src="{{url_for('static', filename='js/joinExistingSession.js')}}"></script>
 <script src="{{url_for('static', filename='js/session_config.js')}}"></script>

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -6,7 +6,7 @@
     <h2>Session Configuration</h2>
     {% if update %}
     <p class="text-center">You are already in an active session.</p>
-    <h4 class="text-center">{{ unit }} {{ currentSession.sessionName }} {{ currentSession.sessionTime }} {{ currentSession.sessionDate }}</h4>
+    <h4 class="text-center">{{ unit }}<span id="currentSessionName">{{ currentSession.sessionName }}</span><span id="currentSessionTime">{{ currentSession.sessionTime }}</span><span id="currentSessionDate">{{ currentSession.sessionDate }}</span></h4>
     <p>Edit the session configuration below.</p>
     {% else %}
     <p class="text-center">

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -14,7 +14,7 @@
     </p>
     {% endif %}
 </div>
-<form method="POST" {% if update %} data-update="true" {% else %} data-update="false"{% endif %}>
+<form method="POST" id="sessionForm" {% if update %} data-update="true" {% else %} data-update="false"{% endif %}>
     <div class="d-flex justify-content-center">
         <div>
             {{ form.hidden_tag() }}

--- a/app/templates/session.html
+++ b/app/templates/session.html
@@ -8,7 +8,7 @@
     <p class="text-center">You are already in an active session.<br>
         To configure a new session, first exit this session from the home page.
     </p>
-    <h4 class="text-center">{{ unit }}<span id="currentSessionName">{{ currentSession.sessionName }}</span><span id="currentSessionTime">{{ currentSession.sessionTime }}</span><span id="currentSessionDate">{{ currentSession.sessionDate }}</span></h4>
+    <h4 class="text-center">{{ unit }} <span id="currentSessionName">{{ currentSession.sessionName }}</span> <span id="currentSessionTime">{{ currentSession.sessionTime }}</span> <span id="currentSessionDate">{{ currentSession.sessionDate }}</span></h4>
     <p class="text-center">Edit the current session details below.</p>		
     {% else %}
     <p class="text-center">


### PR DESCRIPTION
Added a modal popup to first confirm changes made to the session details
Can either confirm (will go ahead and make the changes) or can press the x to stop it from happening
If the modal is clicked, then the join existing session may come up after if applicable