### PR TITLE
Ensure session details (names and times) match first unit displayed

### DIFF
--- a/app/helpers.py
+++ b/app/helpers.py
@@ -38,17 +38,21 @@ def set_session_form_select_options(form):
     # gets units for the facilitator (i.e. the current user)
     units = current_user.unitsFacilitate
     unit_choices = []
+    first_unit_displayed_index = -1 # this var is the index of the unit in unitsFacilitate list
     for unit in units :
         # format with unitID as value, unitCode as option string name
         if check_unit_is_current(unit) :
+            if first_unit_displayed_index == -1 :
+                first_unit_displayed_index = units.index(unit)
             unit_choices.append((unit.unitID, unit.unitCode))
 
     session_name_choices = []
     session_time_choices = []
 
-    if len(units) != 0 :
+    # if there is at least one current unit, set it to that first displayed unit's details
+    if first_unit_displayed_index != -1 :
         # get session names for first unit
-        session_names = units[0].sessionNames.split('|')
+        session_names = units[first_unit_displayed_index].sessionNames.split('|')
         for name in session_names :
             session_name_choices.append((name, name))
 
@@ -57,7 +61,7 @@ def set_session_form_select_options(form):
         form.session_name.default = ''
 
         # get session times for first unit
-        session_times = units[0].sessionTimes.split('|')
+        session_times = units[first_unit_displayed_index].sessionTimes.split('|')
         for time in session_times :
             session_time_choices.append((time, time))
 
@@ -71,7 +75,7 @@ def set_session_form_select_options(form):
             form.session_time.default = time_suggestion
 
         # set first unit as default
-        form.unit.default = units[0].unitID
+        form.unit.default = units[first_unit_displayed_index].unitID
 
     else :
         print("User has no units to facilitate. Sending an empty form.")


### PR DESCRIPTION
Before, the first unit in unitsFacilitate's details were used, with no check as to whether that unit was current causing a mismatch in unit and unit details in session config if there are inactive units
Fixed to ensure the details supplied are the first **current** unit